### PR TITLE
抽出結果確認画面で画像が高さ 100% を超えないように修正

### DIFF
--- a/frontend/src/app/confirm-silhouette/page.tsx
+++ b/frontend/src/app/confirm-silhouette/page.tsx
@@ -31,7 +31,7 @@ const ConfirmSilhouette = () => {
       <Box
         component="img"
         src={image}
-        sx={{ aspectRatio: 1, objectFit: "contain" }}
+        sx={{ width: "100%", aspectRatio: 1, objectFit: "contain" }}
       />
       <Stack direction="row" spacing={4}>
         <Link href="/take-picture">


### PR DESCRIPTION
close #51 
